### PR TITLE
Avoid ambiguous reference compilation error

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -115,9 +115,9 @@ int main(int argc, char ** argv) {
     }
 
     CGraph graph;
-    uint64_t totalTime = 0,
-             initTime = 0, 
-             spentTime = 0, 
+    ::uint64_t totalTime = 0,
+             initTime = 0,
+             spentTime = 0,
              loadingTime = 0,
              algorithmTime = 0;
 


### PR DESCRIPTION
The attached change avoids the following compilation error under GCC-4.9 (Mac OS)

```
SCD/source/main.cpp: In function 'int main(int, char**)':
SCD/source/main.cpp:118:5: error: reference to 'uint64_t' is ambiguous
     uint64_t totalTime = 0,
     ^
```
